### PR TITLE
Support naming Try branches

### DIFF
--- a/README.lhs
+++ b/README.lhs
@@ -391,11 +391,18 @@ If you call `setExperimentTry` more than once, it will append (not overwrite)
 candidate branches. If any candidate is deemed ignored or a mismatch, the
 overall result will be.
 
-**NOTE**: We do not support naming `try` branches.
+`setExperimentTryNamed` can be used to give branches explicit names (otherwise,
+they are "control", "candidate", "candidate-{n}"). These names are visible in
+`ResultControl`, `ResultCandidate`, and `resultDetailsExecutionOrder`.
 
 ### [No control, just candidates](https://github.com/github/scientist#no-control-just-candidates)
 
-Not supported, since we don't support naming `try` branches.
+Not supported.
+
+To support the lack of a Control branch in the types would ultimately lead to a
+runtime error if you attempt to run an Experiment that doesn't have one, and
+doesn't have, or hasn't named, a Candidate to use instead. This feature is not
+worth that lack of runtime safety in our opinion.
 
 <!--
 ```haskell

--- a/README.lhs
+++ b/README.lhs
@@ -257,6 +257,7 @@ data MyPayload = MyPayload
   , context :: Maybe MyContext
   , control :: Value
   , candidate :: Value
+  , execution_order :: [Text]
   }
 
 statsdTiming :: Text -> a -> m ()
@@ -321,8 +322,8 @@ storeMismatchData details = do
       , context = eContext
       , control = controlObservationPayload $ resultDetailsControl details
       , candidate = candidateObservationPayload $ resultDetailsCandidate details
+      , execution_order = resultDetailsExecutionOrder details
       }
-      -- NOTE: execution_order not supported
 
     key = "science." <> eName <> ".mismatch"
 

--- a/README.lhs
+++ b/README.lhs
@@ -399,10 +399,10 @@ they are "control", "candidate", "candidate-{n}"). These names are visible in
 
 Not supported.
 
-To support the lack of a Control branch in the types would ultimately lead to a
-runtime error if you attempt to run an Experiment that doesn't have one, and
-doesn't have, or hasn't named, a Candidate to use instead. This feature is not
-worth that lack of runtime safety in our opinion.
+Supporting the lack of a Control branch in the types would ultimately lead to a
+runtime error if you attempt to run such an `Experiment` without having and
+naming a Candidate to use instead, or severely complicate the types to account
+for that safely. In our opinion, this feature is not worth either of those.
 
 <!--
 ```haskell

--- a/library/Scientist/Experiment/Run.hs
+++ b/library/Scientist/Experiment/Run.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 
 module Scientist.Experiment.Run
@@ -60,13 +61,18 @@ isExperimentEnabled ex
 runControl :: MonadIO m => m (Control a) -> m (ResultControl a)
 runControl control = do
   (Control a, d) <- measureDuration control
-  pure ResultControl { resultControlValue = a, resultControlDuration = d }
+  pure ResultControl
+    { resultControlName = "control"
+    , resultControlValue = a
+    , resultControlDuration = d
+    }
 
 runCandidate :: MonadUnliftIO m => NamedCandidate m b -> m (ResultCandidate b)
 runCandidate nc = do
   (b, d) <- measureDuration $ runNamedCandidate nc
   pure $ ResultCandidate
-    { resultCandidateValue = b
+    { resultCandidateName = namedCandidateName nc
+    , resultCandidateValue = b
     , resultCandidateDuration = d
     }
 

--- a/library/Scientist/NamedCandidate.hs
+++ b/library/Scientist/NamedCandidate.hs
@@ -1,0 +1,25 @@
+module Scientist.NamedCandidate
+  ( NamedCandidate
+  , namedCandidate
+  , namedCandidateName
+  , runNamedCandidate
+  ) where
+
+import Prelude
+
+import Control.Monad.IO.Unlift (MonadUnliftIO)
+import Data.Text (Text)
+import Scientist.Candidate
+import UnliftIO.Exception (SomeException, tryAny)
+
+data NamedCandidate m a = NamedCandidate Text (m (Candidate a))
+
+namedCandidate :: Text -> m (Candidate a) -> NamedCandidate m a
+namedCandidate = NamedCandidate
+
+namedCandidateName :: NamedCandidate m a -> Text
+namedCandidateName (NamedCandidate x _) = x
+
+runNamedCandidate
+  :: MonadUnliftIO m => NamedCandidate m a -> m (Either SomeException a)
+runNamedCandidate (NamedCandidate _ f) = tryAny $ unCandidate <$> f

--- a/library/Scientist/Result.hs
+++ b/library/Scientist/Result.hs
@@ -54,11 +54,13 @@ resultDetailsCandidate :: ResultDetails c a b -> ResultCandidate b
 resultDetailsCandidate = NE.head . resultDetailsCandidates
 
 data ResultControl a = ResultControl
-  { resultControlValue :: a
+  { resultControlName :: Text
+  , resultControlValue :: a
   , resultControlDuration :: Duration
   }
 
 data ResultCandidate a = ResultCandidate
-  { resultCandidateValue :: Either SomeException a
+  { resultCandidateName :: Text
+  , resultCandidateValue :: Either SomeException a
   , resultCandidateDuration :: Duration
   }

--- a/library/Scientist/Result.hs
+++ b/library/Scientist/Result.hs
@@ -8,22 +8,17 @@ module Scientist.Result
   , ResultDetails(..)
   , resultDetailsCandidate
   , ResultControl(..)
-  , runControl
   , ResultCandidate(..)
-  , runCandidate
   ) where
 
 import Prelude
 
-import Control.Monad.IO.Class (MonadIO(..))
-import Control.Monad.IO.Unlift (MonadUnliftIO(..))
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NE
 import Data.Text (Text)
-import Scientist.Candidate
 import Scientist.Control
 import Scientist.Duration
-import UnliftIO.Exception (SomeException, tryAny)
+import UnliftIO.Exception (SomeException)
 
 data Result c a b
     = ResultSkipped (Control a)
@@ -63,30 +58,7 @@ data ResultControl a = ResultControl
   , resultControlDuration :: Duration
   }
 
-runControl :: MonadIO m => m (Control a) -> m (ResultControl a)
-runControl control = do
-  (Control a, d) <- measureDuration control
-  pure ResultControl { resultControlValue = a, resultControlDuration = d }
-
 data ResultCandidate a = ResultCandidate
   { resultCandidateValue :: Either SomeException a
   , resultCandidateDuration :: Duration
   }
-
-runCandidate :: MonadUnliftIO m => m (Candidate b) -> m (ResultCandidate b)
-runCandidate candidate = do
-  (b, d) <- measureDuration $ tryAny candidate
-  pure $ ResultCandidate
-    { resultCandidateValue = unCandidate <$> b
-    , resultCandidateDuration = d
-    }
-
---  x.raised?
---  x.exception.class/message/backtrace
---  x.value
---  x.cleaned_value
--- data ResultItemDetails a = ResultItemDetails
---     { resultItemName :: Maybe Text
---     , resultItemDuration :: Duration
---     , resultItemValue :: Either SomeException a
---     }

--- a/library/Scientist/Result.hs
+++ b/library/Scientist/Result.hs
@@ -45,6 +45,7 @@ data ResultDetails c a b = ResultDetails
   , resultDetailsExperimentContext :: Maybe c
   , resultDetailsControl :: ResultControl a
   , resultDetailsCandidates :: NonEmpty (ResultCandidate b)
+  , resultDetailsExecutionOrder :: [Text]
   }
 
 resultDetailsControlValue :: ResultDetails c a b -> a

--- a/library/Scientist/Result/Evaluate.hs
+++ b/library/Scientist/Result/Evaluate.hs
@@ -5,6 +5,7 @@ module Scientist.Result.Evaluate
 import Prelude
 
 import Data.List.NonEmpty (NonEmpty)
+import Data.Text (Text)
 import Scientist.Candidate
 import Scientist.Control
 import Scientist.Experiment
@@ -14,8 +15,9 @@ evaluateResult
   :: Experiment m c a b
   -> ResultControl a
   -> NonEmpty (ResultCandidate b)
+  -> [Text]
   -> Result c a b
-evaluateResult ex control candidates
+evaluateResult ex control candidates order
   | any (ignore control) candidates = ResultIgnored details
   | all (match control) candidates = ResultMatched details
   | otherwise = ResultMismatched details
@@ -35,4 +37,5 @@ evaluateResult ex control candidates
     , resultDetailsExperimentContext = getExperimentContext ex
     , resultDetailsControl = control
     , resultDetailsCandidates = candidates
+    , resultDetailsExecutionOrder = order
     }

--- a/scientist.cabal
+++ b/scientist.cabal
@@ -16,6 +16,7 @@ library
       Scientist.Duration
       Scientist.Experiment
       Scientist.Experiment.Run
+      Scientist.NamedCandidate
       Scientist.Result
       Scientist.Result.Evaluate
   other-modules:

--- a/tests/Scientist/Experiment/RunSpec.hs
+++ b/tests/Scientist/Experiment/RunSpec.hs
@@ -169,6 +169,36 @@ spec = do
 
       expectMismatched result $ \_ -> pure ()
 
+    it "supports implicitly named candidates" $ do
+      result <-
+        experimentRunInternal
+        $ setExperimentCompare experimentCompareEq
+        $ setExperimentTry (pure A)
+        $ setExperimentTry (pure A)
+        $ setExperimentTry (pure A)
+        $ newExperiment "test" (pure A)
+
+      expectMatched result $ \rd -> do
+        resultControlName (resultDetailsControl rd) `shouldBe` "control"
+
+        map resultCandidateName (NE.toList $ resultDetailsCandidates rd)
+          `shouldMatchList` ["candidate", "candidate-1", "candidate-2"]
+
+    it "supports explicitly named candidates" $ do
+      result <-
+        experimentRunInternal
+        $ setExperimentCompare experimentCompareEq
+        $ setExperimentTryNamed "who" (pure A)
+        $ setExperimentTryNamed "what" (pure A)
+        $ setExperimentTryNamed "when" (pure A)
+        $ newExperiment "test" (pure A)
+
+      expectMatched result $ \rd -> do
+        resultControlName (resultDetailsControl rd) `shouldBe` "control"
+
+        map resultCandidateName (NE.toList $ resultDetailsCandidates rd)
+          `shouldMatchList` ["who", "what", "when"]
+
 expectSkippedWith :: (Eq a, Show a) => Result c a b -> a -> IO ()
 expectSkippedWith result a =
   expectSkipped result $ \(Control b) -> b `shouldBe` a


### PR DESCRIPTION
github/scientist supports (optionally) naming Try branches. That enables the
following features:

1. In the case of multiple candidates, you can see in results which is which
1. In the overall result, you can see what order things ran (by name)
1. You can setup an experiment with no Control, and choose the result by naming
   a Candidate

This PR supports 1 and 2 now, but not 3. To accomplish this we would have to
change `experimentUse` to `Maybe (m (Control a))`, which has tons of rippled
effects and ultimately must produce a runtime error if you run without either
having a Control or having and naming a Candidate. I don't think giving up that
type-safety is worth this feature.

Review by commit might be good again:

- Support Naming candidate branches
- Include names in ResultControl/Candidate
- Report names in ResultControl/Candidate
- Track and report execution-order in Result
