### PR TITLE
Switch to clock library

### DIFF
--- a/library/Scientist/Duration.hs
+++ b/library/Scientist/Duration.hs
@@ -17,9 +17,6 @@ import qualified System.Clock as Clock
 --
 -- >> 1.005
 -- 1.005s
---
--- >> toNanoSecs 1.005
--- 1005000000
 newtype Duration = Duration
   { _unDuration :: Nano
   }

--- a/library/Scientist/Duration.hs
+++ b/library/Scientist/Duration.hs
@@ -42,27 +42,27 @@ measureDuration f = do
 -- | Convert from duration to seconds
 --
 -- >> toSecs 0.000001
--- >> 0.000001
+-- 0.000001
 toSecs :: Duration -> Double
 toSecs = realToFrac
 
 -- | Convert to duration from seconds
 --
 -- >> toSecs 0.000001
--- >> 0.000001s
+-- 0.000001s
 fromSecs :: Double -> Duration
 fromSecs = realToFrac
 
 -- | Convert from duration to nanoseconds
 --
 -- >> toNanoSecs 0.000001
--- >> 1000
+-- 1000
 toNanoSecs :: Duration -> Integer
 toNanoSecs (Duration (MkFixed x)) = x
 
 -- | Convert to duration from nanoseconds
 --
 -- >> fromNanoSecs 1000
--- >> 0.000001s
+-- 0.000001s
 fromNanoSecs :: Integer -> Duration
 fromNanoSecs = Duration . MkFixed

--- a/library/Scientist/Duration.hs
+++ b/library/Scientist/Duration.hs
@@ -7,6 +7,7 @@ module Scientist.Duration
   ( Duration
   , measureDuration
   , toNanoSecs
+  , fromNanoSecs
   ) where
 
 import Prelude
@@ -35,8 +36,19 @@ measureDuration :: MonadIO m => m a -> m (a, Duration)
 measureDuration f = do
   begin <- liftIO getTime
   (,) <$> f <*> liftIO
-    (Duration . MkFixed . Clock.toNanoSecs . subtract begin <$> getTime)
+    (fromNanoSecs . Clock.toNanoSecs . subtract begin <$> getTime)
   where getTime = Clock.getTime Clock.Monotonic
 
+-- | Convert to duration from nanoseconds
+--
+-- >> toNanoSecs 0.000001
+-- >> 1000
 toNanoSecs :: Duration -> Integer
 toNanoSecs (Duration (MkFixed x)) = x
+
+-- | Convert to duration from nanoseconds
+--
+-- >> fromNanoSecs 1000
+-- >> 0.000001s
+fromNanoSecs :: Integer -> Duration
+fromNanoSecs = Duration . MkFixed

--- a/library/Scientist/Duration.hs
+++ b/library/Scientist/Duration.hs
@@ -12,6 +12,7 @@ import Prelude
 import Control.Monad.IO.Class (MonadIO(..))
 import qualified System.Clock as Clock
 
+-- | Time elapsed in nano seconds
 newtype Duration = Duration
   { unDuration :: Integer
   }

--- a/library/Scientist/Duration.hs
+++ b/library/Scientist/Duration.hs
@@ -1,11 +1,11 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
-
-
 module Scientist.Duration
   ( Duration
   , measureDuration
+  , toSecs
+  , fromSecs
   , toNanoSecs
   , fromNanoSecs
   ) where
@@ -39,7 +39,21 @@ measureDuration f = do
     (fromNanoSecs . Clock.toNanoSecs . subtract begin <$> getTime)
   where getTime = Clock.getTime Clock.Monotonic
 
--- | Convert to duration from nanoseconds
+-- | Convert from duration to seconds
+--
+-- >> toSecs 0.000001
+-- >> 0.000001
+toSecs :: Duration -> Double
+toSecs = realToFrac
+
+-- | Convert to duration from seconds
+--
+-- >> toSecs 0.000001
+-- >> 0.000001s
+fromSecs :: Double -> Duration
+fromSecs = realToFrac
+
+-- | Convert from duration to nanoseconds
 --
 -- >> toNanoSecs 0.000001
 -- >> 1000

--- a/library/Scientist/Duration.hs
+++ b/library/Scientist/Duration.hs
@@ -48,7 +48,7 @@ toSecs = realToFrac
 
 -- | Convert to duration from seconds
 --
--- >> toSecs 0.000001
+-- >> fromSecs 0.000001
 -- 0.000001s
 fromSecs :: Double -> Duration
 fromSecs = realToFrac

--- a/library/Scientist/Duration.hs
+++ b/library/Scientist/Duration.hs
@@ -4,10 +4,7 @@
 module Scientist.Duration
   ( Duration
   , measureDuration
-  , toSecs
-  , fromSecs
-  , toNanoSecs
-  , fromNanoSecs
+  , durationToSeconds
   ) where
 
 import Prelude
@@ -43,22 +40,8 @@ measureDuration f = do
 --
 -- >> toSecs 0.000001
 -- 0.000001
-toSecs :: Duration -> Double
-toSecs = realToFrac
-
--- | Convert to duration from seconds
---
--- >> fromSecs 0.000001
--- 0.000001s
-fromSecs :: Double -> Duration
-fromSecs = realToFrac
-
--- | Convert from duration to nanoseconds
---
--- >> toNanoSecs 0.000001
--- 1000
-toNanoSecs :: Duration -> Integer
-toNanoSecs (Duration (MkFixed x)) = x
+durationToSeconds :: Duration -> Double
+durationToSeconds = realToFrac
 
 -- | Convert to duration from nanoseconds
 --

--- a/package.yaml
+++ b/package.yaml
@@ -28,7 +28,7 @@ library:
     - MonadRandom
     - random-shuffle
     - text
-    - time
+    - clock
     - unliftio
     - unliftio-core
 
@@ -39,7 +39,6 @@ tests:
     dependencies:
       - hspec
       - scientist
-      - time
       - unliftio
 
   readme:

--- a/scientist.cabal
+++ b/scientist.cabal
@@ -29,9 +29,9 @@ library
   build-depends:
       MonadRandom
     , base >4 && <5
+    , clock
     , random-shuffle
     , text
-    , time
     , unliftio
     , unliftio-core
   if impl(ghc >= 8.10)
@@ -74,7 +74,6 @@ test-suite spec
       base >4 && <5
     , hspec
     , scientist
-    , time
     , unliftio
   if impl(ghc >= 8.10)
     ghc-options: -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module

--- a/tests/Scientist/Experiment/RunSpec.hs
+++ b/tests/Scientist/Experiment/RunSpec.hs
@@ -223,5 +223,5 @@ expectMismatched result f = case result of
   ResultMismatched rd -> f rd
   _ -> expectationFailure "Expected result to be Mismatched"
 
-isDurationNear :: Integer -> Duration -> Bool
-isDurationNear x = isWithinOf x 50_000_000 . toNanoSecs
+isDurationNear :: Duration -> Duration -> Bool
+isDurationNear x = isWithinOf x 50_000_000

--- a/tests/Scientist/Experiment/RunSpec.hs
+++ b/tests/Scientist/Experiment/RunSpec.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Scientist.Experiment.RunSpec
@@ -55,7 +54,7 @@ spec = do
         $ setExperimentCompare experimentCompareEq
         $ setExperimentTry (pure A)
         $ setExperimentTry (pure A)
-        $ newExperiment "test" (A <$ threadDelay 100_000)
+        $ newExperiment "test" (A <$ threadDelay (100 * 1000))
 
       expectMatched result $ \rd -> do
         resultDetailsExperimentName rd `shouldBe` "test"

--- a/tests/Scientist/Experiment/RunSpec.hs
+++ b/tests/Scientist/Experiment/RunSpec.hs
@@ -55,14 +55,14 @@ spec = do
         $ setExperimentCompare experimentCompareEq
         $ setExperimentTry (pure A)
         $ setExperimentTry (pure A)
-        $ newExperiment "test" (A <$ threadDelay (100 * 1000))
+        $ newExperiment "test" (A <$ threadDelay 100_000)
 
       expectMatched result $ \rd -> do
         resultDetailsExperimentName rd `shouldBe` "test"
 
         let control = resultDetailsControl rd
         resultControlValue control `shouldBe` A
-        resultControlDuration control `shouldSatisfy` isDurationNear 100_000_000
+        resultControlDuration control `shouldSatisfy` isDurationNear 0.100
 
         let
           (failed, succeeded) =
@@ -224,4 +224,4 @@ expectMismatched result f = case result of
   _ -> expectationFailure "Expected result to be Mismatched"
 
 isDurationNear :: Duration -> Duration -> Bool
-isDurationNear x = isWithinOf x 50_000_000
+isDurationNear x = isWithinOf x 0.050

--- a/tests/Scientist/Experiment/RunSpec.hs
+++ b/tests/Scientist/Experiment/RunSpec.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Scientist.Experiment.RunSpec
@@ -10,7 +11,6 @@ import Scientist.Test
 
 import Data.Either (partitionEithers)
 import qualified Data.List.NonEmpty as NE
-import Data.Time (NominalDiffTime)
 import Scientist.Candidate
 import Scientist.Control
 import Scientist.Duration
@@ -62,7 +62,7 @@ spec = do
 
         let control = resultDetailsControl rd
         resultControlValue control `shouldBe` A
-        resultControlDuration control `shouldSatisfy` isDurationNear 0.100
+        resultControlDuration control `shouldSatisfy` isDurationNear 100_000_000
 
         let
           (failed, succeeded) =
@@ -223,5 +223,5 @@ expectMismatched result f = case result of
   ResultMismatched rd -> f rd
   _ -> expectationFailure "Expected result to be Mismatched"
 
-isDurationNear :: NominalDiffTime -> Duration -> Bool
-isDurationNear x = isWithinOf x 0.050 . unDuration
+isDurationNear :: Integer -> Duration -> Bool
+isDurationNear x = isWithinOf x 50_000_000 . toNanoSecs


### PR DESCRIPTION
The `time` library is not ideal for checking duration of operations. It
is heavy handed from a performance perspective and also includes lower
level systems issues where clock resets can mischaracterize actual
elapsed time. Libraries like `criterion` use their own low level `c`
components to check system time, but the `clock` library abstracts this
behavior nicely. For our purposes we can use a monotonic clock to ensure
we are always accurately depicting wall time of an operation.

This additionally swaps `Duration`'s implementation out for an `Integer`
representing nano seconds. This allows easy implementation of numeric
type classes.