### PR TITLE
Remove clock dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+## [_unreleased_](https://github.com/freckle/scientist-hs/compare/v0.0.0.0...main)
+
+- Remove dependency on `clock` in favor of `GHC.Clock`.
+
+## [v0.0.0.0](https://github.com/freckle/scientist-hs/releases/tag/v0.0.0.0)
+
+- Initial release

--- a/library/Scientist/Duration.hs
+++ b/library/Scientist/Duration.hs
@@ -11,7 +11,8 @@ import Prelude
 
 import Control.Monad.IO.Class (MonadIO(..))
 import Data.Fixed (Fixed(..), Nano, showFixed)
-import qualified System.Clock as Clock
+import GHC.Clock (getMonotonicTimeNSec)
+import GHC.Word (Word64)
 
 -- | Time elapsed in seconds up to nanosecond precision
 --
@@ -28,10 +29,8 @@ instance Show Duration where
 
 measureDuration :: MonadIO m => m a -> m (a, Duration)
 measureDuration f = do
-  begin <- liftIO getTime
-  (,) <$> f <*> liftIO
-    (fromNanoSecs . Clock.toNanoSecs . subtract begin <$> getTime)
-  where getTime = Clock.getTime Clock.Monotonic
+  begin <- liftIO getMonotonicTimeNSec
+  (,) <$> f <*> liftIO (fromNanoSecs . subtract begin <$> getMonotonicTimeNSec)
 
 -- | Convert from duration to seconds
 --
@@ -44,5 +43,5 @@ durationToSeconds = realToFrac
 --
 -- >> fromNanoSecs 1000
 -- 0.000001s
-fromNanoSecs :: Integer -> Duration
-fromNanoSecs = Duration . MkFixed
+fromNanoSecs :: Word64 -> Duration
+fromNanoSecs = Duration . MkFixed . fromIntegral

--- a/package.yaml
+++ b/package.yaml
@@ -6,6 +6,10 @@ github: freckle/scientist-hs
 synopsis: A Haskell library for carefully refactoring critical paths.
 description: Please see README.md
 
+extra-doc-files:
+  - README.md
+  - CHANGELOG.md
+
 dependencies:
   - base > 4 && < 5
 
@@ -33,7 +37,6 @@ library:
     - MonadRandom
     - random-shuffle
     - text
-    - clock
     - unliftio
     - unliftio-core
 

--- a/scientist.cabal
+++ b/scientist.cabal
@@ -1,4 +1,4 @@
-cabal-version: 1.12
+cabal-version: 1.18
 
 -- This file has been generated from package.yaml by hpack version 0.34.4.
 --
@@ -12,7 +12,12 @@ category:       Utils
 homepage:       https://github.com/freckle/scientist-hs#readme
 bug-reports:    https://github.com/freckle/scientist-hs/issues
 maintainer:     Freckle Education
+license:        MIT
+license-file:   LICENSE
 build-type:     Simple
+extra-doc-files:
+    README.md
+    CHANGELOG.md
 
 source-repository head
   type: git
@@ -39,7 +44,6 @@ library
   build-depends:
       MonadRandom
     , base >4 && <5
-    , clock
     , random-shuffle
     , text
     , unliftio


### PR DESCRIPTION
When exploring the new version of `Data.Pool` I noticed it was getting
monotonic time from `GHC.Clock`. I did not know this module exists, but
it is a very simple foreign function interface. There is no reason to
rely on the `clock` package when this exists.

This also adds a changelog to the repo.